### PR TITLE
Change order of chmod arguments to improve compatibility with non-GNU

### DIFF
--- a/zsh-universal-variables.zsh
+++ b/zsh-universal-variables.zsh
@@ -29,7 +29,7 @@ PID="pid.$$"
 # and sets only permissions on the user
 mkdir -p /tmp/zsh.$(whoami)
 echo "" >| /tmp/zsh.$(whoami)/${PTS}
-chmod 700 -R /tmp/zsh.$(whoami)
+chmod -R 700 /tmp/zsh.$(whoami)
 
 autoload -U add-zsh-hook
 add-zsh-hook preexec _omz_universalvariables_preexec


### PR DESCRIPTION
On OSX (ie BSD) it is not possible to specify arguments part way through the chmod command. They must be specified up front. GNU chmod doesn't care, so this has no impact there. 